### PR TITLE
Added MANIFEST.in so that README.md gets included in the sdist archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+graft plumbing
+include LICENSE.txt
+include README.md
+
+global-exclude *.py[co] __pycache__ *.so *.pyd

--- a/plumbing/__init__.py
+++ b/plumbing/__init__.py
@@ -1,7 +1,7 @@
 b'This module needs Python 2.7.x'
 
 # Special variables #
-__version__ = '2.0.1'
+__version__ = '2.0.3'
 
 # Expose objects #
 from cmd import command

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
         name             = 'plumbing',
-        version          = '2.0.1',
+        version          = '2.0.2',
         description      = 'Helps with plumbing-type programing in python',
         long_description = open('README.md').read(),
         license          = 'MIT',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
         name             = 'plumbing',
-        version          = '2.0.2',
+        version          = '2.0.3',
         description      = 'Helps with plumbing-type programing in python',
         long_description = open('README.md').read(),
         license          = 'MIT',
@@ -12,4 +12,14 @@ setup(
         classifiers      = ['Topic :: Scientific/Engineering :: Bio-Informatics'],
         packages         = ['plumbing'],
         install_requires = ['sh', 'biopython'],
+
+        # Install extra dependencies:
+        # $ pip install =e.[dev]
+        extras_require={
+            'dev': [
+                'setuptools',
+                'sphinx',
+                'sphinx_rtd_theme',
+            ],
+        },
     )


### PR DESCRIPTION
I noticed that the plumbing-2.0.1.tar.gz package in PyPI is not installing with pip due to README.md being missing from the archive (it throws a FileNotFoundError due to the open('README.md') in setup.py). I added a MANIFEST.in so distutils will include README.md.
